### PR TITLE
Small improvements

### DIFF
--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -880,9 +880,6 @@ impl App {
         if let Some(err) = &self.error_message {
             ui.colored_label(Color32::RED, err);
         }
-
-        let color_str = self.display_color(&self.picker.current_color);
-
         ui.horizontal(|ui| {
             ui.label("Current color: ");
             if ui
@@ -906,8 +903,9 @@ impl App {
             {
                 self.add_cur_color();
             }
-            ui.monospace(&color_str);
         });
+        let c = self.picker.current_color;
+        self.color_box_label_side(&c, vec2(25., 25.), ui, tex_allocator);
 
         self.handle_display_picker(ui, tex_allocator);
 
@@ -972,8 +970,8 @@ impl App {
                     self.handle_zoom_picker(ui, picker);
                     #[cfg(windows)]
                     self.handle_zoom_picker(ui, picker);
-                    self.color_box_label_side(&color, vec2(25., 25.), ui, tex_allocator);
                 });
+                self.color_box_label_side(&color, vec2(25., 25.), ui, tex_allocator);
             }
         };
     }

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -957,6 +957,9 @@ impl App {
             if let Ok(color) = picker.get_color_under_cursor() {
                 if ui.ctx().input().key_pressed(egui::Key::P) {
                     self.picker.set_cur_color(color);
+                    if self.settings_window.settings.auto_copy_picked_color {
+                        let _ = save_to_clipboard(self.clipboard_color(&color));
+                    }
                 }
                 if ui.ctx().input().key_pressed(egui::Key::Z) {
                     self.toggle_zoom_window(&picker);

--- a/src/app/settings.rs
+++ b/src/app/settings.rs
@@ -115,6 +115,10 @@ pub struct Settings {
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
     pub harmony_display_color_label: bool,
+    /// Automatically copy the picked color to the clipboard
+    #[serde(default)]
+    #[serde(skip_serializing_if = "is_false")]
+    pub auto_copy_picked_color: bool,
 }
 
 impl Default for Settings {
@@ -134,6 +138,7 @@ impl Default for Settings {
             harmony_layout: HarmonyLayout::default(),
             harmony_color_size: DEFAULT_COLOR_SIZE,
             harmony_display_color_label: false,
+            auto_copy_picked_color: false,
         }
     }
 }

--- a/src/app/ui/windows/settings.rs
+++ b/src/app/ui/windows/settings.rs
@@ -334,6 +334,10 @@ impl SettingsWindow {
                     ui,
                 );
             });
+        ui.checkbox(
+            &mut self.settings.auto_copy_picked_color,
+            "Auto copy picked color",
+        );
         ui.add_space(HALF_SPACE);
         if ui.button("Custom formats …").clicked() {
             self.custom_formats_window.show = true;

--- a/src/color/format.rs
+++ b/src/color/format.rs
@@ -125,9 +125,7 @@ impl<'a> ColorFormat<'a> {
 
                         match digit_format {
                             Some(
-                                fmt
-                                @
-                                (DigitFormat::Hex
+                                fmt @ (DigitFormat::Hex
                                 | DigitFormat::UppercaseHex
                                 | DigitFormat::Octal
                                 | DigitFormat::Decimal),


### PR DESCRIPTION
- More consistent layout for color indicators
- Option to auto copy picked color to clipboard when pressing P
- Let rustfmt format a file

Here is the new layout:
![image](https://user-images.githubusercontent.com/1521976/171055866-d5b6f3db-fc83-4868-a83d-757625dc58e1.png)
