### PR TITLE
Fix program freeze when dragging a color

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Zoom window can now be enabled by dragging the zoom button, this way the main window stays in focus and colors from other windows can be extracted. [#41](https://github.com/vv9k/epick/pull/41)
 - Set app icon on OS taskbar
 - Revert back to default display format when currently used custom format is deleted
+- Fix program freeze when fragging a color [#45](https://github.com/vv9k/epick/pull/45)
 
 # 0.6.0
 - Add support for persistent configuration. A configuration file with a YAML syntax will be loaded on startup from appropriate config directory depending on OS.

--- a/src/app/ui/mod.rs
+++ b/src/app/ui/mod.rs
@@ -72,10 +72,10 @@ pub fn drag_source(ui: &mut Ui, id: Id, body: impl FnOnce(&mut Ui)) {
         // Normally you need to decide a location for a widget first,
         // because otherwise that widget cannot interact with the mouse.
         // However, a dragged component cannot be interacted with anyway
-        // (anything with `Order::Tooltip` always gets an empty `Response`)
+        // (anything with `Order::Tooltip` always gets an empty [`Response`])
         // So this is fine!
 
-        if let Some(pointer_pos) = ui.input().pointer.interact_pos() {
+        if let Some(pointer_pos) = ui.ctx().pointer_interact_pos() {
             let delta = pointer_pos - response.rect.center();
             ui.ctx().translate_layer(layer_id, delta);
         }
@@ -115,12 +115,12 @@ pub fn drop_target<R>(
 
     ui.painter().set(
         where_to_put_background,
-        Shape::Rect(RectShape {
+        epaint::RectShape {
             rounding: style.rounding,
             fill,
             stroke,
             rect,
-        }),
+        },
     );
 
     InnerResponse::new(ret, response)


### PR DESCRIPTION
Should resolve #44 . 


Tested locally and before this PR I could reproduce the issue, now the colors correctly get dragged.