### PR TITLE
Add a way to scale the UI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+#
+- Add a way to scale the UI in the settings
+
 # 0.9.0
 - Change button layout in palette view
 - Bring back ability to select color by primary clicking it

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -74,6 +74,7 @@ impl eframe::App for App {
                 app: &mut app_ctx,
                 egui: ctx,
                 tex_manager: &mut tex_manager,
+                frame: Some(frame),
             };
             ctx.egui.output().cursor_icon = ctx.app.cursor_icon;
 
@@ -95,7 +96,7 @@ impl eframe::App for App {
             self.display_windows(&mut ctx);
 
             #[cfg(not(target_arch = "wasm32"))]
-            frame.set_window_size(ctx.egui.used_size());
+            ctx.set_window_size(ctx.egui.used_size());
 
             ctx.app.picker.check_for_change();
 
@@ -172,6 +173,7 @@ impl App {
                 app: &mut app_ctx,
                 egui: &context.egui_ctx,
                 tex_manager: &mut tex_manager,
+                frame: None,
             };
 
             ctx.app.load_palettes(context.storage);
@@ -390,7 +392,7 @@ impl App {
     }
 
     fn display_windows(&mut self, ctx: &mut FrameCtx<'_>) {
-        self.windows.settings.display(ctx.app, ctx.egui);
+        self.windows.settings.display(ctx);
         self.windows.settings.custom_formats_window.display(
             &mut ctx.app.settings,
             ctx.egui,

--- a/src/app/mod.rs
+++ b/src/app/mod.rs
@@ -11,7 +11,7 @@ use crate::keybinding::{default_keybindings, KeyBindings};
 use crate::render::{render_gradient, TextureManager};
 use crate::save_to_clipboard;
 use crate::screen_size::ScreenSize;
-use crate::settings;
+use crate::settings::{self, DEFAULT_PIXELS_PER_POINT};
 use crate::ui::{
     colorbox::{ColorBox, COLORBOX_PICK_TOOLTIP},
     colors::*,
@@ -82,6 +82,8 @@ impl eframe::App for App {
             if ctx.app.screen_size != screen_size {
                 ctx.set_styles(screen_size);
             }
+            ctx.egui
+                .set_pixels_per_point(ctx.app.settings.pixels_per_point);
 
             ctx.app.check_settings_change();
 
@@ -199,6 +201,13 @@ impl App {
             .insert(0, "Firacode".to_owned());
 
         context.egui_ctx.set_fonts(fonts);
+
+        if app_ctx.settings.pixels_per_point == DEFAULT_PIXELS_PER_POINT {
+            app_ctx.settings.pixels_per_point = context
+                .integration_info
+                .native_pixels_per_point
+                .unwrap_or(DEFAULT_PIXELS_PER_POINT);
+        }
 
         CONTEXT.try_insert(RwLock::new(app_ctx)).unwrap();
 

--- a/src/app/window/settings.rs
+++ b/src/app/window/settings.rs
@@ -82,6 +82,7 @@ impl SettingsWindow {
                     self.color_spaces(ctx.app, ui);
                     ui.add_space(SPACE);
 
+                    #[cfg(not(target_arch = "wasm32"))]
                     ui.horizontal(|ui| {
                         ui.label("UI Scale");
                         let mut ppp = ctx.app.settings.pixels_per_point;

--- a/src/app/window/settings.rs
+++ b/src/app/window/settings.rs
@@ -5,6 +5,7 @@ use crate::app::{
 use crate::color::{
     ChromaticAdaptationMethod, ColorHarmony, Illuminant, PaletteFormat, RgbWorkingSpace,
 };
+use crate::context::FrameCtx;
 use crate::settings::{ColorDisplayFmtEnum, Settings};
 use crate::ui::{DOUBLE_SPACE, HALF_SPACE, SPACE};
 
@@ -48,16 +49,16 @@ impl SettingsWindow {
         self.message = None;
     }
 
-    pub fn display(&mut self, app_ctx: &mut AppCtx, ctx: &egui::Context) {
+    pub fn display(&mut self, ctx: &mut FrameCtx<'_>) {
         if self.show {
-            let offset = ctx.style().spacing.slider_width * WINDOW_X_OFFSET;
+            let offset = ctx.egui.style().spacing.slider_width * WINDOW_X_OFFSET;
             let mut show = true;
-            let is_dark_mode = ctx.style().visuals.dark_mode;
+            let is_dark_mode = ctx.egui.style().visuals.dark_mode;
             Window::new("settings")
                 .frame(window::default_frame(is_dark_mode))
                 .open(&mut show)
                 .default_pos((offset, WINDOW_Y_OFFSET))
-                .show(ctx, |ui| {
+                .show(ctx.egui, |ui| {
                     window::apply_default_style(ui, is_dark_mode);
                     if let Some(err) = &self.error {
                         ui.colored_label(Color32::RED, err);
@@ -66,19 +67,19 @@ impl SettingsWindow {
                         ui.colored_label(Color32::GREEN, msg);
                     }
 
-                    self.color_formats(app_ctx, ui);
+                    self.color_formats(ctx.app, ui);
                     ui.add_space(HALF_SPACE);
-                    self.rgb_working_space(app_ctx, ui);
+                    self.rgb_working_space(ctx.app, ui);
                     ui.add_space(HALF_SPACE);
-                    self.illuminant(app_ctx, ui);
+                    self.illuminant(ctx.app, ui);
                     ui.add_space(HALF_SPACE);
-                    self.chromatic_adaptation_method(app_ctx, ui);
+                    self.chromatic_adaptation_method(ctx.app, ui);
                     ui.add_space(HALF_SPACE);
-                    self.color_harmony(app_ctx, ui);
+                    self.color_harmony(ctx.app, ui);
                     ui.add_space(HALF_SPACE);
-                    ui.checkbox(&mut app_ctx.settings.cache_colors, "Cache colors");
+                    ui.checkbox(&mut ctx.app.settings.cache_colors, "Cache colors");
                     ui.add_space(DOUBLE_SPACE);
-                    self.color_spaces(app_ctx, ui);
+                    self.color_spaces(ctx.app, ui);
                     ui.add_space(SPACE);
                     self.save_settings_btn(app_ctx, ui);
                 });

--- a/src/app/window/settings.rs
+++ b/src/app/window/settings.rs
@@ -81,7 +81,17 @@ impl SettingsWindow {
                     ui.add_space(DOUBLE_SPACE);
                     self.color_spaces(ctx.app, ui);
                     ui.add_space(SPACE);
-                    self.save_settings_btn(app_ctx, ui);
+
+                    ui.horizontal(|ui| {
+                        ui.label("UI Scale");
+                        let mut ppp = ctx.app.settings.pixels_per_point;
+                        let rsp = ui.add(egui::Slider::new(&mut ppp, 0.25..=3.0));
+                        if !rsp.dragged() {
+                            ctx.app.settings.pixels_per_point = ppp;
+                        }
+                    });
+
+                    self.save_settings_btn(ctx.app, ui);
                 });
 
             if !show {

--- a/src/context.rs
+++ b/src/context.rs
@@ -299,9 +299,13 @@ impl<'frame> FrameCtx<'frame> {
         self.egui.set_style(style);
     }
 
+    #[cfg(not(target_arch = "wasm32"))]
     pub fn set_window_size(&mut self, size: egui::Vec2) {
         if let Some(frame) = &mut self.frame {
             frame.set_window_size(size);
         }
     }
+
+    #[cfg(target_arch = "wasm32")]
+    pub fn set_window_size(&mut self, _: egui::Vec2) {}
 }

--- a/src/context.rs
+++ b/src/context.rs
@@ -253,6 +253,7 @@ pub struct FrameCtx<'frame> {
     pub app: &'frame mut AppCtx,
     pub egui: &'frame egui::Context,
     pub tex_manager: &'frame mut TextureManager,
+    pub frame: Option<&'frame mut eframe::Frame>,
 }
 
 impl<'frame> FrameCtx<'frame> {
@@ -296,5 +297,11 @@ impl<'frame> FrameCtx<'frame> {
         let mut style = (*self.egui.style()).clone();
         style.spacing.slider_width = slider_size / 2.;
         self.egui.set_style(style);
+    }
+
+    pub fn set_window_size(&mut self, size: egui::Vec2) {
+        if let Some(frame) = &mut self.frame {
+            frame.set_window_size(size);
+        }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -11,6 +11,8 @@ use std::collections::HashMap;
 use std::fs;
 use std::path::{Path, PathBuf};
 
+pub const DEFAULT_PIXELS_PER_POINT: f32 = 1.0;
+
 pub fn load_global(_storage: Option<&dyn eframe::Storage>) -> Option<Settings> {
     #[cfg(target_arch = "wasm32")]
     if let Some(storage) = _storage {
@@ -163,6 +165,12 @@ pub struct Settings {
     #[serde(default)]
     #[serde(skip_serializing_if = "is_false")]
     pub auto_copy_picked_color: bool,
+    #[serde(default = "default_pixels_per_point")]
+    pub pixels_per_point: f32,
+}
+
+fn default_pixels_per_point() -> f32 {
+    DEFAULT_PIXELS_PER_POINT
 }
 
 impl Default for Settings {
@@ -185,6 +193,7 @@ impl Default for Settings {
             harmony_color_size: DEFAULT_COLOR_SIZE,
             harmony_display_color_label: false,
             auto_copy_picked_color: false,
+            pixels_per_point: DEFAULT_PIXELS_PER_POINT,
         }
     }
 }

--- a/src/settings.rs
+++ b/src/settings.rs
@@ -166,11 +166,16 @@ pub struct Settings {
     #[serde(skip_serializing_if = "is_false")]
     pub auto_copy_picked_color: bool,
     #[serde(default = "default_pixels_per_point")]
+    #[serde(skip_serializing_if = "is_default_pixels_per_point")]
     pub pixels_per_point: f32,
 }
 
 fn default_pixels_per_point() -> f32 {
     DEFAULT_PIXELS_PER_POINT
+}
+
+fn is_default_pixels_per_point(ppp: &f32) -> bool {
+    *ppp == DEFAULT_PIXELS_PER_POINT
 }
 
 impl Default for Settings {


### PR DESCRIPTION
At this moment `egui` doesn't expose current monitor size so it is impossible (to my knowledge) to automatically scale thus requiring the user to manually adjust the slider in the settings. The UI scale persists throughout launches as it is saved along with the settings.

Closes: #50